### PR TITLE
Option to run multiple sim indices per job

### DIFF
--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -1747,7 +1747,7 @@ class XFaster(object):
         opts = dict(pol=self.pol if pol is None else pol)
         if self.alm_pixel_weights:
             if self.lmax > 1.5 * self.nside:
-                raise RuntimeError(
+                raise ValueError(
                     "Cannot use pixel weights for map2alm, lmax {} is > "
                     "1.5 * nside for nside={}".format(self.lmax, self.nside)
                 )
@@ -6388,7 +6388,7 @@ class XFaster(object):
 
         # check parameter space
         if all([x is None for x in priors.values()]):
-            raise RuntimeError("Empty parameter space")
+            raise ValueError("Empty parameter space")
 
         out = dict(
             r_prior=r_prior,


### PR DESCRIPTION
New `num_sims` option for `xfaster run` and `xfaster submit` that runs the prerequisite checkpoints once, then repeats the data, bandpowers and likelihood checkpoints, incrementing the value of `sim_index_default` each time. This option can be used for simple sets of sims where all of the input data are determined by the `sim_data_components` and `sim_index_default` options. More complex sim sets can be constructed using the `XFasterJobGroup` structure.

To run 100 simple sims efficiently, run one sim with `sim_index_default=0` to pre-compute the prerequisite checkpoints, then split the remaining 99 sims into multiple jobs by setting the `sim_index_default` and `num_sims` options to loop over subsets of the full range of sim indices.  For example, running the rest of the sims in a single job can be done with options `sim_index_default=1` and `num_sims=99`.